### PR TITLE
Update dependencies due to Duo client CA bundle expiration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+2.2.0 2026-01-20
+
+Updated duo-client dependency due to Duo certificate authority bundle expiration.
+Updated API version to 1.8 in MANIFEST.
+Bumped plugin version to 2.2.0 in MANIFEST.
+Updated required Python version to 3.12 in Pipfile.
+Added six as a development dependency in Pipfile.
+
 2.1.0 2021-11-26
 
 Allow users to request OTP via text message

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,7 +1,7 @@
-api: 1.2
+api: 1.8
 type: aa
 name: SPS_Duo
-version: 2.1.0
+version: 2.2.0
 description: Duo Multi-Factor Authentication plugin
 entry_point: main.py
 author_name: One Identity PAM Integration Team

--- a/Pipfile
+++ b/Pipfile
@@ -3,7 +3,8 @@ duo-client = "*"
 
 [dev-packages]
 duo-client = "*"
-oneidentity-safeguard-sessions-plugin-sdk = "~=1.2.0"
+oneidentity-safeguard-sessions-plugin-sdk = "~=1.8.0"
+six = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.12"


### PR DESCRIPTION
- Updated `duo-client` dependency to address Duo certificate authority bundle expiration.
- Bumped API version to 1.8 and plugin version to 2.2.0 in `MANIFEST`.
- Updated required Python version to 3.12.
- Added `six` as a development dependency.