### PR TITLE
Change Python and Plugin SDK API version requirements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2.2.1 2026-01-26
+
+Changed API version to 1.7 in MANIFEST in order to support SPS 7.0 LTS.
+Changed required Python version to 3.8 in Pipfile in order to support SPS 7.0 LTS.
+Bumped plugin version to 2.2.1 in MANIFEST.
+
 2.2.0 2026-01-20
 
 Updated duo-client dependency due to Duo certificate authority bundle expiration.

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,7 +1,7 @@
-api: 1.8
+api: 1.7
 type: aa
 name: SPS_Duo
-version: 2.2.0
+version: 2.2.1
 description: Duo Multi-Factor Authentication plugin
 entry_point: main.py
 author_name: One Identity PAM Integration Team

--- a/Pipfile
+++ b/Pipfile
@@ -3,8 +3,8 @@ duo-client = "*"
 
 [dev-packages]
 duo-client = "*"
-oneidentity-safeguard-sessions-plugin-sdk = "~=1.8.0"
+oneidentity-safeguard-sessions-plugin-sdk = "~=1.7.2"
 six = "*"
 
 [requires]
-python_version = "3.12"
+python_version = "3.8"


### PR DESCRIPTION
- Changed API version to 1.7 in MANIFEST in order to support SPS 7.0 LTS
- Changed required Python version to 3.8 in Pipfile in order to support SPS 7.0 LTS
- Bumped plugin version to 2.2.1 in MANIFEST